### PR TITLE
libdc1394: Fix the bbappend to use bb.utils.contains

### DIFF
--- a/recipes/libdc1394/libdc1394_%.bbappend
+++ b/recipes/libdc1394/libdc1394_%.bbappend
@@ -2,5 +2,5 @@
 # remove the append
 
 DEPENDS += "libxv virtual/libsdl virtual/libx11 libusb1 libraw1394 \
-            ${@base_contains('DISTRO_FEATURES', 'opengl', 'virtual/libgl libglu', '', d)}"
+            ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'virtual/libgl libglu', '', d)}"
  


### PR DESCRIPTION
base_contains is deprecated past 2.2 release

Signed-off-by: Khem Raj <raj.khem@gmail.com>