### PR TITLE
bec.conf: Disable uninative

### DIFF
--- a/conf/distro/bec.conf
+++ b/conf/distro/bec.conf
@@ -64,10 +64,10 @@ ERROR_QA_append = " ${WARN_TO_ERROR_QA}"
 USER_CLASSES ?= "buildstats buildhistory buildstats-summary image-mklibs image-prelink"
 
 require conf/distro/include/no-static-libs.inc
-require conf/distro/include/yocto-uninative.inc
+#require conf/distro/include/yocto-uninative.inc
 require conf/distro/include/security_flags.inc
 
-INHERIT += "uninative"
+#INHERIT += "uninative"
 
 DISTRO_FEATURES_append = " largefile opengl ptest multiarch wayland pam "
 


### PR DESCRIPTION
When we have gcc7 on build host this will cause
problems since libcstdc++ inside uninative is not
good enough for handing gcc7 built native apps

We can re-enable it when yocto project adds support
for gcc7 into uninative

Signed-off-by: Khem Raj <raj.khem@gmail.com>