### PR TITLE
distro: Prefer new pkgconf for managing .pc files

### DIFF
--- a/conf/distro/bec.conf
+++ b/conf/distro/bec.conf
@@ -74,3 +74,6 @@ DISTRO_FEATURES_append = " largefile opengl ptest multiarch wayland pam "
 # Enable thumb2 by default
 ARM_INSTRUCTION_SET = "thumb"
 
+PREFERRED_PROVIDER_pkgconfig = "pkgconf"
+PREFERRED_PROVIDER_pkgconfig-native = "pkgconf-native"
+PREFERRED_PROVIDER_nativesdk-pkgconfig = "nativesdk-pkgconf"


### PR DESCRIPTION
This implementation is in C and quite fast in processing
and supports sysroots and cross compiles better than old
pkgconfig

Signed-off-by: Khem Raj <raj.khem@gmail.com>