### PR TITLE
systemd: Prepend needed space for an append operator

### DIFF
--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,1 +1,1 @@
-PACKAGECONFIG_append = "resolved networkd"
+PACKAGECONFIG_append = " resolved networkd "


### PR DESCRIPTION
Signed-off-by: Khem Raj <raj.khem@gmail.com>