### PR TITLE
bec.conf: Promote unknown-configure-option to a QA error

### DIFF
--- a/conf/distro/bec.conf
+++ b/conf/distro/bec.conf
@@ -57,7 +57,7 @@ BB_DANGLINGAPPENDS_WARNONLY = "1"
 # QA check settings - a little stricter than the OE-Core defaults
 WARN_TO_ERROR_QA = "already-stripped compile-host-path install-host-path \
                     installed-vs-shipped ldflags pn-overrides rpaths staticdev \
-                    useless-rpaths"
+                    unknown-configure-option useless-rpaths"
 WARN_QA_remove = "${WARN_TO_ERROR_QA}"
 ERROR_QA_append = " ${WARN_TO_ERROR_QA}"
 #ERROR_QA_remove  = "split-strip"


### PR DESCRIPTION
Currently, its just a warning

Signed-off-by: Khem Raj <raj.khem@gmail.com>